### PR TITLE
Update bdroid_buildcfg.h

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -18,6 +18,6 @@
 #define _BDROID_BUILDCFG_H
 
 #define BTA_DISABLE_DELAY 100 /* in milliseconds */
-
+#define BLE_VND_INCLUDED TRUE /* enable BLE as we have confirmed it working on hammerhead */
 #define BTM_BLE_ADV_TX_POWER {-21, -15, -7, 1, 9}
 #endif


### PR DESCRIPTION
enable BLE as we have confirmed it working on hammerhead

https://groups.google.com/forum/#!searchin/kevo-alpha/nexus$205/kevo-alpha/-bOQs8V6KU0/nUbnTmJE1RYJ
